### PR TITLE
Fix #1 - replace deprecated DatatypeConverter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,7 @@ javaSource in Test := baseDirectory.value / "src/test/scala"
 libraryDependencies ++= Seq(
   "com.github.scopt" %% "scopt" % "3.7.0",
   "org.apache.commons" % "commons-compress" % "1.15",
+  "commons-codec" % "commons-codec" % "1.11",
   "org.scalatest" %% "scalatest" % "3.0.4" % "test"
 )
 

--- a/src/main/scala/gwen/gpm/process/FileIO.scala
+++ b/src/main/scala/gwen/gpm/process/FileIO.scala
@@ -21,9 +21,9 @@ import java.security.MessageDigest
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.zip.{ZipEntry, ZipInputStream, ZipOutputStream}
-import javax.xml.bind.DatatypeConverter
 
 import gwen.gpm.Errors
+import org.apache.commons.codec.binary.Hex
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
 import org.apache.commons.compress.utils.IOUtils
@@ -125,7 +125,7 @@ object FileIO {
       } finally {
         in.close()
       }
-      (file, DatatypeConverter.printHexBinary(digest.digest()).toLowerCase)
+      (file, Hex.encodeHexString(digest.digest()).toLowerCase)
     }
 
     /**
@@ -147,7 +147,7 @@ object FileIO {
       } finally {
         in.close()
       }
-      DatatypeConverter.printHexBinary(digest.digest()).toLowerCase
+      Hex.encodeHexString(digest.digest()).toLowerCase
     }
 
     /**


### PR DESCRIPTION
Use commons-code library instead of deprecated DatatypeConverter to calculate checksums.